### PR TITLE
Optional/model average

### DIFF
--- a/correlatoranalyser/model_average.py
+++ b/correlatoranalyser/model_average.py
@@ -131,15 +131,24 @@ class FitState:
                     )
                 avg_single_key(key=key)
 
-            return { key: self.param_avg[key] for key in keys }
+            out = {}
+            for res_type_key in ["est","err","bst"]:
+                if res_type_key not in self.param_avg.keys(): continue
+                out[res_type_key] = {key:self.param_avg[res_type_key][key] for key in keys} 
+            return out
+
         elif isinstance(keys, str):
             if keys not in self.keys_all:
                 raise KeyError(
                     f'The given key "{keys}" is not a fit parameter, choose one parameter from {self.keys_all} for the model average.'
                 )
             avg_single_key(key=keys)
-
-            return { key: self.param_avg[key] }
+            
+            out = {}
+            for res_type_key in ["est","err","bst"]:
+                if res_type_key not in self.param_avg.keys(): continue
+                out[res_type_key] = self.param_avg[res_type_key][keys] 
+            return out
         else:
             for key in self.keys_all:
                 avg_single_key(key=key)

--- a/correlatoranalyser/model_average.py
+++ b/correlatoranalyser/model_average.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Self, List, Dict
-from fit import FitResult
+from .fit import FitResult
 import numpy as np
 import gvar as gv
 
@@ -35,7 +35,7 @@ class FitState:
     def model_average(
         self,
         keys: str | list[str] = None,
-    ) -> None:
+    ) -> dict:
         N = len(self.fit_results)
 
         def avg_single_key(key: str) -> None:
@@ -70,39 +70,80 @@ class FitState:
                     pass
                 except KeyError:  # key is not in fit
                     pass
+            
+            if not self.param_avg:
+                self.param_avg["est"] = {}
+                self.param_avg["err"] = {}
 
             # do model average for key for central value fit results
             if self.fit_results[0].AIC is not None:  # check if central value fit
+                # 1) calculate weights from the AIC, where the AIC are normalized s.t. the smallest AICs = 0
+                # This has no effect on the outcome but can prevent overflows for very negative AICs 
                 weights_est = np.exp(-0.5 * (AIC_est - np.min(AIC_est)))
+                # we normalize here already in order to have the normalized weight in the uncertainty computation
+                weights_est /= np.sum(weights_est)
+                # 2) the model average is now simply the weighted average of the parameters
+                # \bar{p} = (\sum_{i=0}^{num_fits} p_i w_i) / (\sum_{i=0} w_i)
                 modelAvg_est = np.average(param_est, weights=weights_est)
-                modelAvg_err = np.average(param_err, weights=weights_est)
-                self.param_avg[key + "_est"] = gv.gvar(modelAvg_est, modelAvg_err)
+                # 3) finally we express the error of parameters by its weighted average according to
+                # Δ\bar{p}^2 = \sum_{i=0}^{num_fits} (Δp_i w_i / (\sum_{j}^{num_fits} w_j) )^2  
+                # TODO: This ignores correlation between the fit results
+                modelAvg_err = np.sqrt(
+                    np.sum(param_err**2*weights_est**2)
+                )
+
+                # finally store the result in the output array
+                self.param_avg["est"][key] = modelAvg_est
+                self.param_avg["err"][key] = modelAvg_err
             # model averaging for bootstrap fit results
             if self.fit_results[0].Nbst is not None:  # check if bootstrap fit
-                weights_bst = np.exp(-0.5 * (AIC_bst - np.min(AIC_bst)))
+                if not self.param_avg:
+                    self.param_avg["bst"] = {}
+                elif "bst" not in self.param_avg:
+                    self.param_avg["bst"] = {}
+                
+                # Steps are similar as above, for the central value results, but extended to every sample result:
+                # 1) calculate weights
+                weights_bst = np.exp(-0.5 * (AIC_bst - np.min(AIC_bst,axis=1)[:,None]))
+                weights_bst /= np.sum(weights_bst, axis = 1)[:,None]
+                # 2) model average
                 modelAvg_bst = np.average(param_bst, weights=weights_bst, axis=1)
-                modelAvg_bst_err = Nbst * [np.std(modelAvg_bst, axis=0)]
-                self.param_avg[key + "_bst"] = gv.gvar(modelAvg_bst, modelAvg_bst_err)
-            return
+                # 3) calculate the uncertainty. This is changed as we don't rely on error propagation but instead 
+                #    compute the combined bootstrap + model average error.
+                #    This is in principle a very conservative estimate as it captures uncertainties on the model.
+                # This potentially overwrites the error above. This IS intended as by default the bootstrap uncertainty is 
+                # more reliable than the simple error propagation!
+                self.param_avg["err"][key] = np.std(modelAvg_bst,axis=0)
+                # if no central value fit is done we simply compute the mean over bootstrap fits
+                # these two values are equal provided, same fitting strategy!
+                if self.fit_results[0].AIC is None:  # check if central value fit
+                    self.param_avg["est"][key] = np.mean(modelAvg_bst, axis = 0)
+                # finally the bootstrap results will be stored too:
+                self.param_avg["bst"][key] = modelAvg_bst
+        # end avg_single_key
 
         # go through all parameters and do model averaging for each of them:
-        if type(keys) is list:
+        if isinstance(keys, list):
             for key in keys:
                 if key not in self.keys_all:
                     raise KeyError(
                         f'The given key "{key}" is not a fit parameter, choose one parameter from {self.keys_all} for the model average.'
                     )
                 avg_single_key(key=key)
-        elif type(keys) is str:
+
+            return { key: self.param_avg[key] for key in keys }
+        elif isinstance(keys, str):
             if keys not in self.keys_all:
                 raise KeyError(
                     f'The given key "{keys}" is not a fit parameter, choose one parameter from {self.keys_all} for the model average.'
                 )
             avg_single_key(key=keys)
+
+            return { key: self.param_avg[key] }
         else:
             for key in self.keys_all:
                 avg_single_key(key=key)
-        return
+            return self.param_avg
 
 
     def __getitem__(self, index: int) -> FitResult:

--- a/correlatoranalyser/model_average.py
+++ b/correlatoranalyser/model_average.py
@@ -104,6 +104,14 @@ class FitState:
                 avg_single_key(key=key)
         return
 
-    def __get_item(index: int) -> FitResult:
+
+    def __getitem__(self, index: int) -> FitResult:
         """method that gets a fit result based on the index in the fit_result list, list is sorted by AIC"""
-        return
+        return self.fit_results[index]
+
+    def __len__(self):
+        """
+            Returns the number of fits which are being tracked.
+        """
+
+        return len(self.fit_results)


### PR DESCRIPTION
A couple of things in this path (everything's open for discussion!!!)

1. I added some comments
2. The error calculation of the model averaged central value fit, should use an add in quadrature instead of a weighted average. This would come out of a error propagation. 
3. TODO: should we add a covariance term to this? 
4. I restructured the output to a dictionary with keys `bst` (optional), `est`, `err`. This way we don't require the user to interact with gvar if they don't want to. 
5. I made sure to return the dictionary at the end of the function with provided keys. 