### PR TITLE
Removed the small sample correction for the linear regression

### DIFF
--- a/correlatoranalyser/fitResult.py
+++ b/correlatoranalyser/fitResult.py
@@ -713,7 +713,7 @@ class FitResult:
             F_statistic = (target_data.T @ weight_matrix @ target_data - residuals.T @ weight_matrix @ residuals) / 2 / (self.chi2/self.dof)
             self.Q_value_res[nres] = 1 - scipy.stats.f.cdf(F_statistic, 2, self.dof)
             
-            self.AIC_res[nres] = self.calculate_AIC( self.chi2_res[nres] )
+            self.AIC_res[nres] = self.calculate_AIC( self.chi2_res[nres], small_sample_correction=False )
             self.aug_AIC_res[nres] = self.AIC_res[nres]
 
             self.prior_res = None
@@ -750,7 +750,7 @@ class FitResult:
             F_statistic = (target_data.T @ weight_matrix @ target_data - residuals.T @ weight_matrix @ residuals) / 2 / (self.chi2/self.dof)
             self.Q_value = 1 - scipy.stats.f.cdf(F_statistic, 2, self.dof)
 
-            self.AIC = self.calculate_AIC( self.chi2 )
+            self.AIC = self.calculate_AIC( self.chi2, small_sample_correction=False)
             self.aug_AIC = self.AIC
 
             self.prior = None


### PR DESCRIPTION
Set the small sample correction to False when calculating the AIC in the import from linear regression method, such that linear fits can now be performed also when less than 4 data points are available